### PR TITLE
Fix typo in pre-merge-unclobber

### DIFF
--- a/.config/vcsh/hooks-enabled/pre-merge-unclobber
+++ b/.config/vcsh/hooks-enabled/pre-merge-unclobber
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# This code does amost exactly what the native VCSH sanity checking code
+# This code does almost exactly what the native VCSH sanity checking code
 # does except that on finding a potential merge conflict, it moves the 
 # extant object out of the way temporarily. The merge then happens cleanly
 # as far as git knows, and a post-merge hook can figure out what to do with


### PR DESCRIPTION
3s/amost/almost/

Thanks for the inspiration of these vcsh hooks, BTW.